### PR TITLE
feat: Change Priore: Bertaina Mario -> Macario Gianmarco

### DIFF
--- a/src/content/news/soci-2025.md
+++ b/src/content/news/soci-2025.md
@@ -1,0 +1,25 @@
+---
+title: "Registro della Compagnia - 2025"
+description: "Elenco dei Soci della Compagnia di Sant'Eligio, aggiornato al 13 luglio 2025."
+date: 2025-07-13
+category: storia
+cover: /santeligio/2024-07-07-foto-gruppo-compagnia.jpg
+coverAlt: "Foto di gruppo dei Soci della Compagnia, luglio 2024"
+---
+
+## Elenco Soci
+
+Aggiornato al 13 luglio 2025.
+
+1. Macario Gianmarco **(Priore)**
+2. Macario Livio
+3. Macario Fulvio
+4. Macario Andrea
+5. Macario Loris
+6. Pettavino Adriana
+7. Pettavino Miriana
+8. Macario Christian
+9. Risso Francesco
+10. Pettavino Paolo
+11. Macario Gianpaolo
+12. Bertaina Mario

--- a/src/pages/storia.astro
+++ b/src/pages/storia.astro
@@ -53,10 +53,9 @@ import Hero from '../components/Hero.astro';
 
     <div id="soci">
       <h2>I Soci della Compagnia</h2>
-      <p>(Ultimo aggiornamento: 7 luglio 2024)</p>
+      <p>(Ultimo aggiornamento: 13 luglio 2025)</p>
       <ol>
-        <li>Bertaina Mario <b>(Priore)</b></li>
-        <li>Macario Gianmarco</li>
+        <li>Macario Gianmarco <b>(Priore)</b></li>
         <li>Macario Livio</li>
         <li>Macario Fulvio</li>
         <li>Macario Andrea</li>
@@ -67,6 +66,7 @@ import Hero from '../components/Hero.astro';
         <li>Risso Francesco</li>
         <li>Pettavino Paolo</li>
         <li>Macario Gianpaolo</li>
+        <li>Bertaina Mario</li>
       </ol>
     </div>
   </article>


### PR DESCRIPTION
## Summary
- Rotates the Priore succession queue: Macario Gianmarco becomes Priore effective 2025-07-13, Bertaina Mario moves to the back of the list.
- Updates `src/pages/storia.astro`'s live "Elenco Soci" list and "Ultimo aggiornamento" date.
- Adds `src/content/news/soci-2025.md` as the dated registry snapshot for this transition.

## Test plan
- [x] `astro build` succeeds and generates `/storia` and `/news/soci-2025` with the new order
- [x] Verified rendered HTML shows Macario Gianmarco `(Priore)` first, Bertaina Mario last

Closes #32