### PR TITLE
fix: correct soci-2024 registry date to 2024-07-07

### DIFF
--- a/src/content/news/soci-2024.md
+++ b/src/content/news/soci-2024.md
@@ -1,7 +1,7 @@
 ---
 title: "Registro della Compagnia - 2024"
-description: "Elenco dei Soci della Compagnia di Sant'Eligio, aggiornato al 14 agosto 2024."
-date: 2024-08-14
+description: "Elenco dei Soci della Compagnia di Sant'Eligio, aggiornato al 7 luglio 2024."
+date: 2024-07-07
 category: storia
 cover: /santeligio/2024-07-07-foto-gruppo-compagnia.jpg
 coverAlt: "Foto di gruppo dei Soci della Compagnia, luglio 2024"
@@ -9,7 +9,7 @@ coverAlt: "Foto di gruppo dei Soci della Compagnia, luglio 2024"
 
 ## Elenco Soci
 
-Aggiornato al 14 agosto 2024.
+Aggiornato al 7 luglio 2024.
 
 1. Bertaina Mario **(Priore)**
 2. Macario Gianmarco

--- a/src/pages/storia.astro
+++ b/src/pages/storia.astro
@@ -53,7 +53,7 @@ import Hero from '../components/Hero.astro';
 
     <div id="soci">
       <h2>I Soci della Compagnia</h2>
-      <p>(Ultimo aggiornamento: 14 agosto 2024)</p>
+      <p>(Ultimo aggiornamento: 7 luglio 2024)</p>
       <ol>
         <li>Bertaina Mario <b>(Priore)</b></li>
         <li>Macario Gianmarco</li>


### PR DESCRIPTION
## Summary
- The 2024 registry snapshot (`src/content/news/soci-2024.md`) and `storia.astro` stated "14 agosto 2024", but the actual date is 2024-07-07 (matching the cover photo filename `2024-07-07-foto-gruppo-compagnia.jpg`).

## Test plan
- [x] `astro build` succeeds