### PR TITLE
Bump required Node.js version to >=20.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Hosted on [Netlify](https://www.netlify.com/).
 
 ## Development
 
-Requires Node.js >= 18.20.8 (or 20+).
+Requires Node.js >= 20.9.0.
 
 ```sh
 npm install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "Sito della Compagnia di Sant'Eligio di Vernante, ricostruito su Astro.",
   "engines": {
-    "node": ">=18.20.8"
+    "node": ">=20.9.0"
   },
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

- `package.json`'s `engines.node` still declared `>=18.20.8` (EOL since April 2025), even though `netlify.toml` already builds with `NODE_VERSION = "20"`. This mismatch is what Netlify's dashboard was flagging in #39.
- Bumps `engines.node` to `>=20.9.0` and updates the README's Node requirement line to match.

## Test plan

- [x] `npm run build` on Node 22 (locally available) — build succeeds unchanged.

Closes #39.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1ZSfHGVtPsP6EHHQLBi2d)_