### PR TITLE
Add privacy policy page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -44,8 +44,11 @@ const year = new Date().getFullYear();
   </div>
 
   <div class="border-t border-ink-800">
-    <p class="mx-auto max-w-5xl px-4 py-4 text-xs text-parchment-200">
-      © 2023–{year} Compagnia di Sant'Eligio. Tutti i diritti riservati.
+    <p
+      class="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 px-4 py-4 text-xs text-parchment-200"
+    >
+      <span>© 2023–{year} Compagnia di Sant'Eligio. Tutti i diritti riservati.</span>
+      <a class="hover:text-gold-500" href="/privacy">Privacy</a>
     </p>
   </div>
 </footer>

--- a/src/pages/contatti.astro
+++ b/src/pages/contatti.astro
@@ -34,7 +34,10 @@ import { SITE } from '../consts';
       Il materiale storico e archivistico pubblicato su questo sito è di
       natura documentaria. I nominativi dei Soci viventi sono pubblicati solo
       con il loro consenso. Per richieste relative ai propri dati, scrivete
-      all'indirizzo sopra indicato.
+      all'indirizzo sopra indicato. Leggi l'
+      <a class="text-wine-700 hover:underline" href="/privacy"
+        >informativa completa sulla privacy</a
+      >.
     </p>
   </section>
 </Base>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,60 @@
+---
+import Base from '../layouts/Base.astro';
+import Hero from '../components/Hero.astro';
+import { SITE } from '../consts';
+---
+
+<Base
+  title="Privacy"
+  description="Informativa sulla privacy del sito della Compagnia di Sant'Eligio di Vernante."
+>
+  <Hero compact image="/santeligio/santeligio_2023.jpg" imageAlt="" title="Privacy" />
+
+  <article class="prose-eligio mx-auto max-w-3xl px-4 py-12">
+    <p>Ultimo aggiornamento: 25 luglio 2026.</p>
+
+    <h2>Titolare del trattamento</h2>
+    <p>
+      Compagnia di Sant'Eligio di Vernante — contatti:
+      <a href={`mailto:${SITE.email}`}>{SITE.email}</a>.
+    </p>
+
+    <h2>Dati raccolti</h2>
+    <p>
+      Questo sito è statico: non prevede registrazione, account utente, moduli
+      di iscrizione o acquisti online. Non utilizziamo cookie di profilazione
+      o di terze parti, né mostriamo pubblicità.
+    </p>
+
+    <h2>Statistiche di utilizzo</h2>
+    <p>
+      Per capire quante persone visitano il sito usiamo
+      <a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener noreferrer">
+        Cloudflare Web Analytics
+      </a>, un servizio che misura le visite in forma aggregata senza
+      utilizzare cookie e senza salvare alcun dato che permetta di
+      identificare o tracciare i singoli visitatori tra siti diversi.
+    </p>
+
+    <h2>Materiale storico e nominativi</h2>
+    <p>
+      Il materiale storico e archivistico pubblicato su questo sito (foto,
+      registri, elenchi) è di natura documentaria. I nominativi dei Soci
+      viventi sono pubblicati solo con il loro consenso.
+    </p>
+
+    <h2>I tuoi diritti</h2>
+    <p>
+      Per richiedere la rimozione o la correzione di un dato che ti riguarda
+      (ad esempio una foto o un nominativo), scrivi all'indirizzo indicato
+      sopra: risponderemo il prima possibile.
+    </p>
+
+    <h2>Modifiche a questa informativa</h2>
+    <p>
+      Questa pagina potrà essere aggiornata in futuro, ad esempio in caso di
+      variazioni nei servizi utilizzati dal sito. La data di ultimo
+      aggiornamento è indicata in cima alla pagina.
+    </p>
+  </article>
+</Base>


### PR DESCRIPTION
## Summary

- Adds `src/pages/privacy.astro` (Italian, matching the site's language) describing what the site actually does: no accounts, no cookies, no ads, no ecommerce — just [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/) for aggregate visit counts, plus the existing living-members-consent rule for archival material (photos, registries).
- Links to `/privacy` from the footer (new line next to the copyright notice) and from the short privacy blurb already on the Contatti page.

## Why not reuse #22

#22 targeted `src/components/Policy/Policy.js`, a Gatsby-era component removed in the Astro rewrite (#30), and its text was generic ecommerce/ads boilerplate (cookie consent, personalized ads, account registration, age-13/18 clauses, anti-spam clauses) that doesn't describe this site — which has no accounts, no purchases, and no cookies. Reusing it verbatim would misstate the site's actual privacy practices, so this PR writes a short, accurate policy from scratch instead.

## Test plan

- [x] `npm run build` succeeds and generates `/privacy/index.html`.

Closes #9.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1ZSfHGVtPsP6EHHQLBi2d)_