### PR TITLE
Serve pre-computed thumbnails on the gallery page

### DIFF
--- a/src/pages/galleria.astro
+++ b/src/pages/galleria.astro
@@ -1,16 +1,16 @@
 ---
 import Base from '../layouts/Base.astro';
 import Hero from '../components/Hero.astro';
-import { Image } from 'astro:assets';
+import { Image, getImage } from 'astro:assets';
 
 // v1: gallery is wired but sparse — filling it with scanned slides and event
 // photos is out of scope for this issue (see santeligio.com#30, phase 2).
 //
-// The grid thumbnails are generated at build time by astro:assets. The
-// originals stay under public/ because other pages reference them by URL
-// (Base.astro's default OG image, the Hero backgrounds, the news covers), so
-// importing them here derives thumbnails from a single source of truth rather
-// than keeping a second copy of ~6.6 MB of photos under src/.
+// The grid thumbnails and the enlarged view are generated at build time by
+// astro:assets. The originals stay under public/ because other pages reference
+// them by URL (Base.astro's default OG image, the Hero backgrounds, the news
+// covers), so importing them here derives every size from a single source of
+// truth rather than keeping a second copy of ~6.6 MB of photos under src/.
 import foto1900 from '../../public/santeligio/santeligio_1900.jpg';
 import convenzione1858 from '../../public/santeligio/20190818-convenzione-1858-pag1.jpg';
 import gruppo2024 from '../../public/santeligio/2024-07-07-foto-gruppo-compagnia.jpg';
@@ -22,33 +22,56 @@ import giugno2024 from '../../public/santeligio/wa-2024-06-10-133426-1.jpeg';
 const images = [
   {
     src: foto1900,
+    original: '/santeligio/santeligio_1900.jpg',
     alt: 'Fotografia storica della Compagnia, 1900 circa',
   },
   {
     src: convenzione1858,
+    original: '/santeligio/20190818-convenzione-1858-pag1.jpg',
     alt: 'Pagina della Convenzione del 1858',
   },
   {
     src: gruppo2024,
+    original: '/santeligio/2024-07-07-foto-gruppo-compagnia.jpg',
     alt: 'Foto di gruppo dei Soci, luglio 2024',
   },
   {
     src: registro2023,
+    original: '/santeligio/santeligio_2023.jpg',
     alt: 'Registro della Compagnia, edizione 2023',
   },
   {
     src: nov2023a,
+    original: '/santeligio/20231125-142120.jpg',
     alt: 'Momento di vita della Compagnia, novembre 2023',
   },
   {
     src: nov2023b,
+    original: '/santeligio/20231125-142205.jpg',
     alt: 'Momento di vita della Compagnia, novembre 2023',
   },
   {
     src: giugno2024,
+    original: '/santeligio/wa-2024-06-10-133426-1.jpeg',
     alt: 'Foto della Compagnia, giugno 2024',
   },
 ];
+
+// The enlarged view is a 1600px WebP rather than the raw original: plenty for
+// viewing, but a fraction of the weight on a slow connection. It is fetched
+// only when a thumbnail is activated, never on page load. The raw original
+// stays one click further away, for anyone who wants the full scan.
+const gallery = await Promise.all(
+  images.map(async (img) => ({
+    ...img,
+    large: await getImage({
+      src: img.src,
+      width: 1600,
+      format: 'webp',
+      quality: 'mid',
+    }),
+  })),
+);
 ---
 
 <Base
@@ -65,21 +88,98 @@ const images = [
     </p>
     <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
       {
-        images.map((img) => (
-          <Image
-            src={img.src}
-            alt={img.alt}
-            widths={[320, 640]}
-            width={640}
-            sizes="(min-width: 640px) 320px, 50vw"
-            format="webp"
-            quality="mid"
-            class="aspect-square w-full rounded-lg object-cover"
-            loading="lazy"
-            decoding="async"
-          />
+        gallery.map((img) => (
+          <a
+            href={img.large.src}
+            data-lightbox
+            data-alt={img.alt}
+            data-original={img.original}
+            class="block rounded-lg"
+          >
+            <Image
+              src={img.src}
+              alt={img.alt}
+              widths={[320, 640]}
+              width={640}
+              sizes="(min-width: 640px) 320px, 50vw"
+              format="webp"
+              quality="mid"
+              class="aspect-square w-full rounded-lg object-cover transition hover:opacity-90"
+              loading="lazy"
+              decoding="async"
+            />
+          </a>
         ))
       }
     </div>
   </section>
+
+  <!--
+    Enlarged view. Native <dialog> so the browser handles focus trapping,
+    Escape-to-close and returning focus to the thumbnail. The thumbnails stay
+    real links, so without JavaScript (or without <dialog> support) they simply
+    open the enlarged image instead.
+  -->
+  <dialog
+    id="lightbox"
+    aria-label="Immagine ingrandita"
+    class="m-auto max-h-[92vh] max-w-[95vw] rounded-lg bg-parchment-50 p-0 backdrop:bg-ink-900/80"
+  >
+    <div class="flex justify-end p-2">
+      <button
+        type="button"
+        id="lightbox-close"
+        autofocus
+        class="rounded px-3 py-1 text-ink-800 hover:bg-parchment-200"
+      >
+        <span aria-hidden="true">✕</span><span class="sr-only">Chiudi</span>
+      </button>
+    </div>
+    <img id="lightbox-img" alt="" class="block max-h-[74vh] w-auto max-w-full" />
+    <p class="px-4 py-3 text-sm">
+      <a id="lightbox-original" class="text-wine-700 underline" href="">
+        Apri l'immagine originale
+      </a>
+    </p>
+  </dialog>
+
+  <script is:inline>
+    (function () {
+      var dlg = document.getElementById('lightbox');
+      // Without <dialog> support the thumbnails keep working as plain links.
+      if (!dlg || typeof dlg.showModal !== 'function') return;
+
+      var img = document.getElementById('lightbox-img');
+      var original = document.getElementById('lightbox-original');
+      var close = document.getElementById('lightbox-close');
+
+      Array.prototype.forEach.call(
+        document.querySelectorAll('a[data-lightbox]'),
+        function (link) {
+          link.addEventListener('click', function (ev) {
+            // Let modified clicks (new tab, download, middle-click) behave normally.
+            if (ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
+            ev.preventDefault();
+            img.src = link.getAttribute('href');
+            img.alt = link.getAttribute('data-alt') || '';
+            original.href = link.getAttribute('data-original');
+            dlg.showModal();
+          });
+        },
+      );
+
+      close.addEventListener('click', function () {
+        dlg.close();
+      });
+      // A click landing on the dialog itself is a click on the backdrop.
+      dlg.addEventListener('click', function (ev) {
+        if (ev.target === dlg) dlg.close();
+      });
+      // Drop the decoded image once closed so it is not held in memory.
+      dlg.addEventListener('close', function () {
+        img.removeAttribute('src');
+        img.alt = '';
+      });
+    })();
+  </script>
 </Base>

--- a/src/pages/galleria.astro
+++ b/src/pages/galleria.astro
@@ -1,36 +1,51 @@
 ---
 import Base from '../layouts/Base.astro';
 import Hero from '../components/Hero.astro';
+import { Image } from 'astro:assets';
 
 // v1: gallery is wired but sparse — filling it with scanned slides and event
 // photos is out of scope for this issue (see santeligio.com#30, phase 2).
+//
+// The grid thumbnails are generated at build time by astro:assets. The
+// originals stay under public/ because other pages reference them by URL
+// (Base.astro's default OG image, the Hero backgrounds, the news covers), so
+// importing them here derives thumbnails from a single source of truth rather
+// than keeping a second copy of ~6.6 MB of photos under src/.
+import foto1900 from '../../public/santeligio/santeligio_1900.jpg';
+import convenzione1858 from '../../public/santeligio/20190818-convenzione-1858-pag1.jpg';
+import gruppo2024 from '../../public/santeligio/2024-07-07-foto-gruppo-compagnia.jpg';
+import registro2023 from '../../public/santeligio/santeligio_2023.jpg';
+import nov2023a from '../../public/santeligio/20231125-142120.jpg';
+import nov2023b from '../../public/santeligio/20231125-142205.jpg';
+import giugno2024 from '../../public/santeligio/wa-2024-06-10-133426-1.jpeg';
+
 const images = [
   {
-    src: '/santeligio/santeligio_1900.jpg',
-    alt: "Fotografia storica della Compagnia, 1900 circa",
+    src: foto1900,
+    alt: 'Fotografia storica della Compagnia, 1900 circa',
   },
   {
-    src: '/santeligio/20190818-convenzione-1858-pag1.jpg',
+    src: convenzione1858,
     alt: 'Pagina della Convenzione del 1858',
   },
   {
-    src: '/santeligio/2024-07-07-foto-gruppo-compagnia.jpg',
+    src: gruppo2024,
     alt: 'Foto di gruppo dei Soci, luglio 2024',
   },
   {
-    src: '/santeligio/santeligio_2023.jpg',
+    src: registro2023,
     alt: 'Registro della Compagnia, edizione 2023',
   },
   {
-    src: '/santeligio/20231125-142120.jpg',
-    alt: "Momento di vita della Compagnia, novembre 2023",
+    src: nov2023a,
+    alt: 'Momento di vita della Compagnia, novembre 2023',
   },
   {
-    src: '/santeligio/20231125-142205.jpg',
-    alt: "Momento di vita della Compagnia, novembre 2023",
+    src: nov2023b,
+    alt: 'Momento di vita della Compagnia, novembre 2023',
   },
   {
-    src: '/santeligio/wa-2024-06-10-133426-1.jpeg',
+    src: giugno2024,
     alt: 'Foto della Compagnia, giugno 2024',
   },
 ];
@@ -51,11 +66,17 @@ const images = [
     <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
       {
         images.map((img) => (
-          <img
+          <Image
             src={img.src}
             alt={img.alt}
+            widths={[320, 640]}
+            width={640}
+            sizes="(min-width: 640px) 320px, 50vw"
+            format="webp"
+            quality="mid"
             class="aspect-square w-full rounded-lg object-cover"
             loading="lazy"
+            decoding="async"
           />
         ))
       }

--- a/src/pages/galleria.astro
+++ b/src/pages/galleria.astro
@@ -3,59 +3,69 @@ import Base from '../layouts/Base.astro';
 import Hero from '../components/Hero.astro';
 import { Image, getImage } from 'astro:assets';
 
-// v1: gallery is wired but sparse — filling it with scanned slides and event
-// photos is out of scope for this issue (see santeligio.com#30, phase 2).
-//
 // The grid thumbnails and the enlarged view are generated at build time by
 // astro:assets. The originals stay under public/ because other pages reference
 // them by URL (Base.astro's default OG image, the Hero backgrounds, the news
 // covers), so importing them here derives every size from a single source of
 // truth rather than keeping a second copy of ~6.6 MB of photos under src/.
-import foto1900 from '../../public/santeligio/santeligio_1900.jpg';
-import convenzione1858 from '../../public/santeligio/20190818-convenzione-1858-pag1.jpg';
-import gruppo2024 from '../../public/santeligio/2024-07-07-foto-gruppo-compagnia.jpg';
-import registro2023 from '../../public/santeligio/santeligio_2023.jpg';
-import nov2023a from '../../public/santeligio/20231125-142120.jpg';
-import nov2023b from '../../public/santeligio/20231125-142205.jpg';
-import giugno2024 from '../../public/santeligio/wa-2024-06-10-133426-1.jpeg';
+//
+// Every image in public/santeligio/ is discovered automatically, so a photo
+// added there can never silently go missing from the gallery — which is how
+// the July 2025 and July 2026 group photos ended up unlisted.
+const files = import.meta.glob<{ default: ImageMetadata }>(
+  '../../public/santeligio/*.{jpg,jpeg,png,webp,avif}',
+  { eager: true },
+);
+const byName = new Map(
+  Object.entries(files).map(([path, mod]) => [path.split('/').pop(), mod.default]),
+);
 
-const images = [
+// Curated order and descriptions. Anything on disk but not listed here is
+// appended below with a generic description, rather than dropped.
+const captions = [
+  { file: 'santeligio_1900.jpg', alt: 'Fotografia storica della Compagnia, 1900 circa' },
+  { file: '20190818-convenzione-1858-pag1.jpg', alt: 'Pagina della Convenzione del 1858' },
+  { file: 'santeligio_2023.jpg', alt: 'Registro della Compagnia, edizione 2023' },
   {
-    src: foto1900,
-    original: '/santeligio/santeligio_1900.jpg',
-    alt: 'Fotografia storica della Compagnia, 1900 circa',
-  },
-  {
-    src: convenzione1858,
-    original: '/santeligio/20190818-convenzione-1858-pag1.jpg',
-    alt: 'Pagina della Convenzione del 1858',
-  },
-  {
-    src: gruppo2024,
-    original: '/santeligio/2024-07-07-foto-gruppo-compagnia.jpg',
-    alt: 'Foto di gruppo dei Soci, luglio 2024',
-  },
-  {
-    src: registro2023,
-    original: '/santeligio/santeligio_2023.jpg',
-    alt: 'Registro della Compagnia, edizione 2023',
-  },
-  {
-    src: nov2023a,
-    original: '/santeligio/20231125-142120.jpg',
+    file: '20231125-142120.jpg',
     alt: 'Momento di vita della Compagnia, novembre 2023',
   },
   {
-    src: nov2023b,
-    original: '/santeligio/20231125-142205.jpg',
+    file: '20231125-142205.jpg',
     alt: 'Momento di vita della Compagnia, novembre 2023',
   },
+  { file: 'wa-2024-06-10-133426-1.jpeg', alt: 'Foto della Compagnia, giugno 2024' },
   {
-    src: giugno2024,
-    original: '/santeligio/wa-2024-06-10-133426-1.jpeg',
-    alt: 'Foto della Compagnia, giugno 2024',
+    file: '2024-07-07-foto-gruppo-compagnia.jpg',
+    alt: 'Foto di gruppo dei Soci della Compagnia, luglio 2024',
+  },
+  {
+    file: '2025-07-13-foto-gruppo-compagnia.jpg',
+    alt: 'Foto di gruppo dei Soci della Compagnia, luglio 2025',
+  },
+  {
+    file: '2026-07-12-foto-gruppo-compagnia.jpg',
+    alt: 'Foto di gruppo dei Soci della Compagnia, luglio 2026',
   },
 ];
+
+const described = new Set(captions.map((c) => c.file));
+const undescribed = [...byName.keys()]
+  .filter((file) => !described.has(file))
+  .sort()
+  .map((file) => ({
+    file,
+    alt: "Fotografia dell'archivio della Compagnia di Sant'Eligio",
+  }));
+
+const images = [...captions, ...undescribed]
+  // Skip captions whose file has since been removed, so the build survives it.
+  .filter((entry) => byName.has(entry.file))
+  .map((entry) => ({
+    src: byName.get(entry.file)!,
+    original: `/santeligio/${entry.file}`,
+    alt: entry.alt,
+  }));
 
 // The enlarged view is a 1600px WebP rather than the raw original: plenty for
 // viewing, but a fraction of the weight on a slow connection. It is fetched
@@ -88,10 +98,11 @@ const gallery = await Promise.all(
     </p>
     <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
       {
-        gallery.map((img) => (
+        gallery.map((img, i) => (
           <a
             href={img.large.src}
             data-lightbox
+            data-index={i}
             data-alt={img.alt}
             data-original={img.original}
             class="block rounded-lg"
@@ -120,27 +131,58 @@ const gallery = await Promise.all(
     real links, so without JavaScript (or without <dialog> support) they simply
     open the enlarged image instead.
   -->
+  <!--
+    A full-viewport dark stage rather than a panel sized to the photo: the
+    photos have very different aspect ratios, and anything smaller either jumps
+    around as you page through them or leaves large empty bands around the
+    portrait ones.
+  -->
   <dialog
     id="lightbox"
     aria-label="Immagine ingrandita"
-    class="m-auto max-h-[92vh] max-w-[95vw] rounded-lg bg-parchment-50 p-0 backdrop:bg-ink-900/80"
+    class="m-0 h-dvh max-h-none w-screen max-w-none bg-ink-900/95 p-0 backdrop:bg-ink-900/80"
   >
-    <div class="flex justify-end p-2">
-      <button
-        type="button"
-        id="lightbox-close"
-        autofocus
-        class="rounded px-3 py-1 text-ink-800 hover:bg-parchment-200"
-      >
-        <span aria-hidden="true">✕</span><span class="sr-only">Chiudi</span>
-      </button>
+    <div class="flex h-full flex-col">
+      <div class="flex items-center justify-between gap-2 p-2">
+        <p id="lightbox-counter" aria-live="polite" class="px-2 text-sm text-parchment-100"></p>
+        <button
+          type="button"
+          id="lightbox-close"
+          autofocus
+          class="grid h-11 w-11 place-items-center rounded text-xl text-parchment-50 hover:bg-parchment-50/20"
+        >
+          <span aria-hidden="true">✕</span><span class="sr-only">Chiudi</span>
+        </button>
+      </div>
+
+      <div class="relative flex min-h-0 flex-1 items-center justify-center px-2">
+        <img
+          id="lightbox-img"
+          alt=""
+          class="max-h-full max-w-full object-contain transition-opacity duration-200 data-[loading]:opacity-40"
+        />
+        <button
+          type="button"
+          id="lightbox-prev"
+          class="absolute left-2 grid h-11 w-11 place-items-center rounded-full bg-parchment-50/90 text-2xl text-ink-900 shadow hover:bg-parchment-50"
+        >
+          <span aria-hidden="true">‹</span><span class="sr-only">Immagine precedente</span>
+        </button>
+        <button
+          type="button"
+          id="lightbox-next"
+          class="absolute right-2 grid h-11 w-11 place-items-center rounded-full bg-parchment-50/90 text-2xl text-ink-900 shadow hover:bg-parchment-50"
+        >
+          <span aria-hidden="true">›</span><span class="sr-only">Immagine successiva</span>
+        </button>
+      </div>
+
+      <p class="px-4 py-3 text-sm">
+        <a id="lightbox-original" class="text-parchment-100 underline" href="">
+          Apri l'immagine originale
+        </a>
+      </p>
     </div>
-    <img id="lightbox-img" alt="" class="block max-h-[74vh] w-auto max-w-full" />
-    <p class="px-4 py-3 text-sm">
-      <a id="lightbox-original" class="text-wine-700 underline" href="">
-        Apri l'immagine originale
-      </a>
-    </p>
   </dialog>
 
   <script is:inline>
@@ -151,22 +193,60 @@ const gallery = await Promise.all(
 
       var img = document.getElementById('lightbox-img');
       var original = document.getElementById('lightbox-original');
+      var counter = document.getElementById('lightbox-counter');
       var close = document.getElementById('lightbox-close');
+      var prev = document.getElementById('lightbox-prev');
+      var next = document.getElementById('lightbox-next');
 
-      Array.prototype.forEach.call(
-        document.querySelectorAll('a[data-lightbox]'),
-        function (link) {
-          link.addEventListener('click', function (ev) {
-            // Let modified clicks (new tab, download, middle-click) behave normally.
-            if (ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
-            ev.preventDefault();
-            img.src = link.getAttribute('href');
-            img.alt = link.getAttribute('data-alt') || '';
-            original.href = link.getAttribute('data-original');
-            dlg.showModal();
-          });
-        },
-      );
+      var links = Array.prototype.slice.call(document.querySelectorAll('a[data-lightbox]'));
+      if (!links.length) return;
+      var current = 0;
+
+      function show(i) {
+        // Wrap around, so neither end is a dead stop.
+        current = (i + links.length) % links.length;
+        var link = links[current];
+        // Dim while the next photo arrives — noticeable on a slow connection.
+        img.dataset.loading = '';
+        img.addEventListener(
+          'load',
+          function () {
+            delete img.dataset.loading;
+          },
+          { once: true },
+        );
+        img.src = link.getAttribute('href');
+        img.alt = link.getAttribute('data-alt') || '';
+        original.href = link.getAttribute('data-original');
+        counter.textContent = current + 1 + ' di ' + links.length;
+      }
+
+      links.forEach(function (link, i) {
+        link.addEventListener('click', function (ev) {
+          // Let modified clicks (new tab, download, middle-click) behave normally.
+          if (ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
+          ev.preventDefault();
+          show(i);
+          dlg.showModal();
+        });
+      });
+
+      prev.addEventListener('click', function () {
+        show(current - 1);
+      });
+      next.addEventListener('click', function () {
+        show(current + 1);
+      });
+
+      dlg.addEventListener('keydown', function (ev) {
+        if (ev.key === 'ArrowLeft') {
+          ev.preventDefault();
+          show(current - 1);
+        } else if (ev.key === 'ArrowRight') {
+          ev.preventDefault();
+          show(current + 1);
+        }
+      });
 
       close.addEventListener('click', function () {
         dlg.close();
@@ -175,10 +255,13 @@ const gallery = await Promise.all(
       dlg.addEventListener('click', function (ev) {
         if (ev.target === dlg) dlg.close();
       });
-      // Drop the decoded image once closed so it is not held in memory.
+      // Return focus to the thumbnail actually being viewed, which may not be
+      // the one that opened the dialog, then drop the decoded image.
       dlg.addEventListener('close', function () {
         img.removeAttribute('src');
         img.alt = '';
+        delete img.dataset.loading;
+        links[current].focus();
       });
     })();
   </script>


### PR DESCRIPTION
Makes https://www.santeligio.com/galleria/ fast on slow connections, adds a navigable lightbox, and lists every photo in `public/santeligio/`.

## Problem

The gallery rendered **full-resolution** photos as 171–320 px squares, and listed only 7 of the 9 files in `public/santeligio/` — the July 2025 and July 2026 group photos (added in #50 and #36) were never added. Scrolling the page pulled **7.2 MB**, including one 3453 KB photo at 3968×2976 and one 2491 KB at 2976×3968.

## Change

`astro:assets` generates every size at build time (sharp already ships with Astro 5.18, so no new dependency):

- **Grid**: 320w/640w WebP via `srcset`/`sizes`.
- **Lightbox**: one 1600w WebP per photo, 34–142 KB instead of up to 3.5 MB.

The originals stay under `public/` — `Base.astro`'s default OG image, the `Hero` backgrounds and the news `cover` fields all reference them by URL — so they're imported here rather than copied into `src/`, keeping one source of truth and no second copy of 7 MB in git.

A detail worth flagging: with `widths` alone, Astro sets the non-srcset `src` fallback to the **full-resolution** WebP — a 424 KB fallback for the 3968 px photo. Adding `width={640}` caps it, which also cut total emitted grid variants from ~1.2 MB to 320 KB.

### Completeness

The photo list is discovered with `import.meta.glob` over `public/santeligio/`, so a photo added there can never silently go missing from the gallery. Captions stay hand-written and define the display order; anything on disk without one is appended with a generic description rather than dropped, and a caption whose file has been removed is skipped rather than breaking the build.

### Lightbox

Native `<dialog>`, so focus trapping, Escape-to-close, backdrop inerting and focus return come from the browser rather than from focus-management code we'd maintain.

- **Navigation**: prev/next buttons and Left/Right arrow keys, wrapping at both ends, with a `n di N` counter in an `aria-live` region.
- Closing returns focus to the thumbnail **being viewed**, not the one that opened the dialog.
- A full-viewport dark stage rather than a panel fitted to the photo — the aspect ratios vary enough that a fitted panel either jumped between images or left large empty bands beside the portrait ones.
- **Costs nothing at page load**: the dialog's `<img>` ships with no `src`, set only on activation.
- Progressive enhancement: thumbnails stay real `<a href>` links to the 1600w image, so without JavaScript — or without `<dialog>` support — they simply open it. Modified clicks (⌘/Ctrl/middle) fall through to normal navigation. The raw original is one click further via "Apri l'immagine originale".

## Measured

Chromium, CDP throttling, viewport 390×844 @2x, cache disabled. **Both sides serve the same 9 photos** — the baseline is `main`'s raw-`<img>` approach with the two missing photos added, so the comparison is like for like.

**Fast 3G** — 1.6 Mbit/s down, 562 ms RTT, median of 3 runs:

| | before | after | change |
|---|---:|---:|---:|
| `load` event | 1.51 s | 1.52 s | +0.9% |
| **scroll through whole gallery** | **39.99 s** | **4.57 s** | **−88.6%** |
| total transfer | 7417.4 KB | 470.1 KB | −93.7% |
| of which images | 7391.5 KB | 433.6 KB | −94.1% |

**Slow 3G** — 400 kbit/s down, 2000 ms RTT:

| | before | after | change |
|---|---:|---:|---:|
| `load` event | 5.49 s | 5.55 s | +1.1% |
| **scroll through whole gallery** | **157.56 s** | **15.62 s** | **−90.1%** |
| total transfer | 7417.4 KB | 470.1 KB | −93.7% |

Opening photos then costs 34–142 KB each on demand; paging through all nine totals 1.2 MB, and only if you actually do it.

### Reading these numbers honestly

**The `load` event does not improve — it is fractionally worse.** The grid is `loading="lazy"`, so only the hero image (54 KB, eager) is fetched before `load`; that was already true. The extra is the `srcset` markup, dialog and script. The entire win is in what happens once the visitor scrolls, which on Slow 3G is the difference between 2½ minutes and 16 seconds.

That also means **the hero image is now the only thing gating `load` on this page**. Optimising it needs `Hero.astro` to accept an `ImageMetadata` alongside its current string path — a shared component used by six pages, so it's left out here. Happy to do as a follow-up.

## Verified

Scripted in Chromium against the built output; 17 assertions, all passing:

- [x] `npm run build` — 11 pages, unchanged.
- [x] All 9 files in `public/santeligio/` appear in the gallery.
- [x] Auto-discovery proven by adding a file and rebuilding: 9 → 10 with the generic caption, back to 9 when removed.
- [x] Grid layout unchanged: thumbnails at 171×171 (mobile) and 320×320 (desktop); 640w WebP selected at DPR 2.
- [x] **No preloading** — one image request per thumbnail plus the hero, with the lightbox idle.
- [x] Opens at the clicked photo; next/prev and Left/Right arrows advance; wraps in both directions; `alt`, counter and original link all track the current photo.
- [x] Focus lands on the close button, returns to the thumbnail being viewed, and never reaches an interactive element behind the dialog.
- [x] Escape closes, including with focus on a nav button; backdrop click closes; `src` dropped on close.
- [x] **axe-core clean** (`wcag2a`/`2aa`/`21a`/`21aa`/`22aa`) with the dialog open and closed.
- [x] **WCAG 2.2 target size** (2.5.8): controls measure 44×44 against the 24×24 minimum.
- [x] With JavaScript disabled, thumbnail links resolve to real images.

## Note

Opening `20231125-142120.jpg` shows it's a paper wrapper labelled *"La bandiera di Sant'Eligio … x il Corpus Domini"* — not "Momento di vita della Compagnia", which it shares verbatim with `20231125-142205.jpg`. Now that the photos are viewable this is more apparent. Left alone since you know what these depict; it's the alt-text quality point already tracked in #49.

---
_Generated by [Claude Code](https://claude.ai/code)_