### PR TITLE
Correct dialectal spelling: Mandulera -> Mandoulera

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,7 +1,7 @@
 import type { it } from './it';
 
 // English copy. Piedmontese and historical terms are deliberately left in the
-// original — Baja, Abbà, Cartunè, Priore, ciuchinere, "La Mandulera" — and
+// original — Baja, Abbà, Cartunè, Priore, ciuchinere, "La Mandoulera" — and
 // glossed on first use, because they name specific local things that have no
 // English equivalent. Needs review by someone who knows the tradition.
 export const en: typeof it = {
@@ -117,7 +117,7 @@ export const en: typeof it = {
     after: [
       'And so we come to the most important and most solemn moment of the celebration. On the church forecourt, after Mass has been celebrated, the outgoing Abbà and the incoming Abbà stand face to face for the handover.',
       'What passes into the hands of the new Priore is not merely a baton, but the history of Vernante itself. The old Abbà formally hands over to the new one the dressed halberds, symbol of the authority and leadership of the Compagnia, and the register of the Compagnia, which holds the names of all those who have held this office over the years. With this gesture, the tradition has officially been passed on.',
-      'Immediately after this handover, solemnity once gave way to sheer popular joy. From the little square known as "La Mandulera" the traditional parade of the "ancient horsemen" would set off: a cheerful, colourful procession winding through the streets of the village, re-enacting that old "people\'s army" celebrating victory and freedom regained. Long live the Baja, long live the Compagnia di Sant\'Eligio, and a good handover to all!',
+      'Immediately after this handover, solemnity once gave way to sheer popular joy. From the little square known as "La Mandoulera" the traditional parade of the "ancient horsemen" would set off: a cheerful, colourful procession winding through the streets of the village, re-enacting that old "people\'s army" celebrating victory and freedom regained. Long live the Baja, long live the Compagnia di Sant\'Eligio, and a good handover to all!',
     ],
     closingBefore:
       'The text of the handover is by Loretta Macario, whom we thank. For more on the history of the Compagnia and the list of members, see the ',

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -116,7 +116,7 @@ export const it = {
     after: [
       "Ed eccoci giunti al momento più importante e sacro della manifestazione. Sul sagrato della Chiesa, dopo la celebrazione della Messa, l'Abbà uscente e l'Abbà entrante si trovano faccia a faccia per il trapasso delle consegne.",
       "Nelle mani del nuovo Priore non passa solo un testimone, ma la storia stessa di Vernante. L'Abbà vecchio consegna ufficialmente al nuovo: le alabarde guarnite, simbolo dell'autorità e della guida della compagnia ed il registro della Compagnia, che custodisce i nomi di tutti coloro che hanno onorato questa carica negli anni. Con questo gesto, il testimone della tradizione è ufficialmente passato.",
-      'Subito dopo questo passaggio, un tempo la solennità lasciava spazio alla pura gioia popolare. Dalla piazzetta "La Mandulera" prendeva il via la tradizionale sfilata dei "cavalieri antichi". Un\'allegra e colorata parata che si snodava per le vie del paese, simulando quell\'antico "esercito popolare" che festeggiava la vittoria e la libertà ritrovata. Viva la Baja, viva la Compagnia di Sant\'Eligio e buon passaggio delle consegne a tutti!',
+      'Subito dopo questo passaggio, un tempo la solennità lasciava spazio alla pura gioia popolare. Dalla piazzetta "La Mandoulera" prendeva il via la tradizionale sfilata dei "cavalieri antichi". Un\'allegra e colorata parata che si snodava per le vie del paese, simulando quell\'antico "esercito popolare" che festeggiava la vittoria e la libertà ritrovata. Viva la Baja, viva la Compagnia di Sant\'Eligio e buon passaggio delle consegne a tutti!',
     ],
     closingBefore:
       "Il testo del passaggio delle consegne è di Loretta Macario, che ringraziamo. Per approfondire la storia della Compagnia e l'elenco dei Soci si veda la pagina ",


### PR DESCRIPTION
Small spelling fix, not a draft.

`Mandoulera` is the correct spelling of the little square's dialectal name, per the site owner. `Mandulera` is currently live in both the Italian original and the English translation (merged via #53).

- `src/i18n/it.ts` — the Baja passage text
- `src/i18n/en.ts` — the translation, plus the terminology note in the file's header comment

French isn't affected here since it hasn't merged yet — #54 carries the same fix for `fr.ts` plus its own occurrence, so all four languages end up consistent once both land.

## Verified

- [x] `npm run build` — 19 pages, unchanged.
- [x] `Mandoulera` renders correctly on both `/baja/` and `/en/baja/`.
- [x] No remaining occurrences of the old spelling anywhere in the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1ZSfHGVtPsP6EHHQLBi2d)_